### PR TITLE
Remove redudant declaration

### DIFF
--- a/backend/internal/api/authentication/facebook_auth.go
+++ b/backend/internal/api/authentication/facebook_auth.go
@@ -135,6 +135,5 @@ func HandleFacebookCallback(w http.ResponseWriter, r *http.Request, db *sql.DB) 
 	http.SetCookie(w, &cookie)
 
 	serverresponse.Message = "Login successful"
-	statusCode = http.StatusOK
 	respondJSON(w, statusCode, serverresponse)
 }

--- a/backend/internal/api/authentication/github _auth.go
+++ b/backend/internal/api/authentication/github _auth.go
@@ -174,7 +174,6 @@ func HandleGitHubCallback(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 
 	// Step 11: Respond success
 	serverresponse.Message = "Login successful"
-	statusCode = http.StatusOK
 	respondJSON(w, statusCode, serverresponse)
 }
 

--- a/backend/internal/api/authentication/google_auth.go
+++ b/backend/internal/api/authentication/google_auth.go
@@ -154,7 +154,6 @@ func HandleGoogleCallback(w http.ResponseWriter, r *http.Request, db *sql.DB) {
 	http.SetCookie(w, &cookie)
 
 	serverresponse.Message = "Login successful"
-	statusCode = http.StatusOK
 	respondJSON(w, statusCode, serverresponse)
 }
 

--- a/backend/server.go
+++ b/backend/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -62,5 +63,7 @@ func main() {
 	})
 
 	fmt.Printf("\n\n\n\t-----------[ server running on http://%s]-------------\n\n", srvAddr)
-	http.ListenAndServe(srvAddr, controllers.CORSMiddleware(mux))
+	if err := http.ListenAndServe(srvAddr, controllers.CORSMiddleware(mux)); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
**✅ Description:**

This pull request makes two key improvements:
 1. Removed redundant statusCode declaration

        File: facebook_auth.go

 The variable statusCode was unnecessarily declared at the start of the function and immediately reassigned later in all code paths.
This cleanup removes the redundancy and resolves the ineffassign linter warning.


 2. Added proper error handling for http.ListenAndServe
        File: server.go
        Previously, the error returned by http.ListenAndServe was not checked.
        This fix wraps the call in an if err != nil block and logs the error using log.Fatalf(...), ensuring startup issues are caught and reported.