### PR TITLE
Title: Integrate Notifications for Follow & Follow Request

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -12,6 +12,27 @@ import (
 )
 
 func NewRouter(db *sql.DB) http.Handler {
+	// Create router
+	mux := http.NewServeMux()
+
+	// create the websocket handler
+	wsManager := ws.NewManager(
+		ws.NewDBSessionResolver(db),
+		ws.NewDBGroupMemberFetcher(db),
+		ws.NewDBMessagePersister(db),
+	)
+	mux.Handle("GET /ws", middleware.AuthMiddleware(db)(http.HandlerFunc(wsManager.HandleConnection)))
+
+	// Chat history handlers (paginated HTTP access to messages)
+	notifier := ws.NewDBNotificationSender(wsManager)
+	chatHandler := ws.NewChatHandler(
+		db,
+		ws.NewDBSessionResolver(db),
+		ws.NewDBMessagePersister(db),
+		notifier,
+		wsManager,
+	)
+
 	// Create stores
 	postStore := store.NewPostStore(db)
 	authStore := store.NewAuthStore(db)
@@ -29,12 +50,9 @@ func NewRouter(db *sql.DB) http.Handler {
 	// Create handlers
 	postHandler := handlers.NewPostHandler(postService)
 	authHandler := handlers.NewAuthHandler(authService)
-	followHandler := handlers.NewFollowHandler(followService)
+	followHandler := handlers.NewFollowHandler(followService, notifier)
 	unfollowHandler := handlers.NewUnfollowHandler(unfollowService)
-	followRequestHandler := handlers.NewFollowRequestHandler(followRequestService)
-
-	// Create router
-	mux := http.NewServeMux()
+	followRequestHandler := handlers.NewFollowRequestHandler(followRequestService, notifier)
 
 	// Authentication Handlers
 	mux.HandleFunc("POST /validate/step1", authHandler.ValidateAccountStepOne)
@@ -62,25 +80,6 @@ func NewRouter(db *sql.DB) http.Handler {
 
 	mux.Handle("GET /me", middleware.AuthMiddleware(db)(http.HandlerFunc(handlers.NewMeHandler(db))))
 	mux.Handle("GET /avatar", http.HandlerFunc(handlers.Avatar))
-
-
-	// create the websocket handler
-	wsManager := ws.NewManager(
-		ws.NewDBSessionResolver(db),
-		ws.NewDBGroupMemberFetcher(db),
-		ws.NewDBMessagePersister(db),
-	)
-	mux.Handle("GET /ws", middleware.AuthMiddleware(db)(http.HandlerFunc(wsManager.HandleConnection)))
-
-	// Chat history handlers (paginated HTTP access to messages)
-	notifier := ws.NewDBNotificationSender(wsManager)
-	chatHandler := ws.NewChatHandler(
-		db,
-		ws.NewDBSessionResolver(db),
-		ws.NewDBMessagePersister(db),
-		notifier,
-		wsManager,
-	)
 
 	/*example websocket routes */
 	mux.Handle("GET /api/messages/private", middleware.AuthMiddleware(db)(http.HandlerFunc(chatHandler.GetPrivateMessages)))

--- a/backend/internal/service/follow_request_service.go
+++ b/backend/internal/service/follow_request_service.go
@@ -17,3 +17,15 @@ func (fr *FollowRequestService) AcceptedFollowConnection(followConnectionID int6
 func (fr *FollowRequestService) RejectedFollowConnection(followConnectionID int64) error {
 	return fr.FollowRequestStore.RejectFollowConnection(followConnectionID)
 }
+
+func (fr *FollowRequestService) RetrieveUserName(userID int64) (string, string, error) {
+	return fr.FollowRequestStore.UserInfo(userID)
+}
+
+func (fr *FollowRequestService) GetRequestInfo(requestID int64) (int64, int64, error) {
+	return fr.FollowRequestStore.RetrieveRequestInfo(requestID)
+}
+
+func (fr *FollowRequestService) AddtoNotification(follower_id int64, message string) error {
+	return fr.FollowRequestStore.AddtoNotification(follower_id, message)
+}

--- a/backend/internal/service/follow_service.go
+++ b/backend/internal/service/follow_service.go
@@ -23,3 +23,11 @@ func (Follow *FollowService) CreateFollowForPublicAccount(followerid, followeeid
 func (Follow *FollowService) CreateFollowForPrivateAccount(followrid, followeeid int64) (int64, error) {
 	return Follow.FollowStore.CreatePrivateFollowConnection(followrid, followeeid)
 }
+
+func (Follow *FollowService) GetUserInfo(userID int64) (string, string, error) {
+	return Follow.FollowStore.UserInfo(userID)
+}
+
+func (Follow *FollowService) AddtoNotification(follower_id int64, message string) error {
+	return Follow.FollowStore.AddtoNotification(follower_id, message)
+}

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -28,6 +28,8 @@ type FollowServiceInterface interface {
 	IsAccountPublic(followeeID int64) (bool, error)
 	CreateFollowForPublicAccount(followerid, followeeid int64) error
 	CreateFollowForPrivateAccount(followrid, followeeid int64) (int64, error)
+	GetUserInfo(userID int64) (string, string, error)
+	AddtoNotification(follower_id int64, message string) error
 }
 
 type UnfollowServiceInterface interface {
@@ -38,4 +40,7 @@ type UnfollowServiceInterface interface {
 type FollowRequestServiceInterface interface {
 	AcceptedFollowConnection(followConnectionID int64) error
 	RejectedFollowConnection(followConnectionID int64) error
+	RetrieveUserName(userID int64) (string, string, error)
+	GetRequestInfo(requestID int64) (int64, int64, error)
+	AddtoNotification(follower_id int64, message string) error
 }

--- a/backend/internal/store/follow_request_store.go
+++ b/backend/internal/store/follow_request_store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -48,4 +49,47 @@ func (fr *FollowRequestStore) GetPendingFollowRequests(followeeID int64) ([]int6
 	}
 
 	return requestIDs, rows.Err()
+}
+
+func (fr *FollowRequestStore) UserInfo(userID int64) (string, string, error) {
+	var firstName, lastName sql.NullString
+	query := "SELECT first_name, last_name FROM Users WHERE id = ?"
+	err := fr.DB.QueryRow(query, userID).Scan(&firstName, &lastName)
+	if err != nil {
+		return "", "", err
+	}
+
+	name := ""
+	if firstName.Valid && lastName.Valid {
+		name = firstName.String + " " + lastName.String
+	} else if firstName.Valid {
+		name = firstName.String
+	} else if lastName.Valid {
+		name = lastName.String
+	} else {
+		name = "User"
+	}
+
+	return name, name, nil
+}
+
+func (fr *FollowRequestStore) RetrieveRequestInfo(requestID int64) (int64, int64, error) {
+	var followerID, followeeID int64
+	query := "SELECT follower_id, followee_id FROM Followers WHERE id = ?"
+	err := fr.DB.QueryRow(query, requestID).Scan(&followerID, &followeeID)
+	return followerID, followeeID, err
+}
+
+func (followstore *FollowRequestStore) AddtoNotification(follower_id int64, message string) error {
+	// Determine notification type based on message content
+	notificationType := "follow_request"
+	if strings.Contains(message, "accepted") {
+		notificationType = "follow_request_accepted"
+	} else if strings.Contains(message, "rejected") {
+		notificationType = "follow_request_rejected"
+	}
+
+	_, err := followstore.DB.Exec(`INSERT INTO Notifications (user_id, type, message) VALUES (?, ?, ?)`,
+		follower_id, notificationType, message)
+	return err
 }


### PR DESCRIPTION
 Summary of Changes:

    Integrated real-time notifications via WebSocket for:

        Follow request sent (for private accounts)

        Follow event (for public accounts)

     Notifications are stored in the database and include key metadata:

        Follower ID, username, and follow request ID (when applicable)

     Initial handling of notification delivery for follow-related events

Backend Notification Behavior:

    Private accounts: Triggers a follow-request notification with a pending status

    Public accounts: Automatically accepts the follow and notifies the followee

 What’s Coming in Future PRs:

    Polish and finalize the full follow/unfollow system

    Enhance and extend the notification system (e.g., mark as read/unread, delete)

    Add cancel follow request functionality for users who change their mind

    Add detailed documentation for follow system 

    Add more tests to cover edge cases and multiple follow scenarios

    Finalize follow request acceptance/rejection handling (server + WebSocket)