### PR TITLE
Add Handlers for Follower/Following Statistics and Lists

### DIFF
--- a/backend/internal/api/handlers/follow_handler.go
+++ b/backend/internal/api/handlers/follow_handler.go
@@ -164,3 +164,18 @@ func (f *FollowHandler) FollowStats(w http.ResponseWriter, r *http.Request) {
 
 	utils.RespondJSON(w, http.StatusOK, followfollowingstat)
 }
+
+func (f *FollowHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
+	userIdstr := r.PathValue("userid")
+	userId, err := strconv.ParseInt(userIdstr, 10, 64)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusBadRequest, utils.Response{Message: "Invalid User Id"})
+		return
+	}
+	followers, err := f.FollowService.GetFollowersList(userId)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusInternalServerError, utils.Response{Message: err.Error()})
+		return
+	}
+	utils.RespondJSON(w, http.StatusOK, followers)
+}

--- a/backend/internal/api/handlers/follow_handler.go
+++ b/backend/internal/api/handlers/follow_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/tajjjjr/social-network/backend/internal/models"
@@ -143,4 +144,23 @@ func (follow *FollowHandler) Follow(w http.ResponseWriter, r *http.Request) {
 
 	serverResponse.Message = "Follow request sent. You will be able to follow once approved."
 	utils.RespondJSON(w, status, serverResponse)
+}
+
+func (f *FollowHandler) FollowStats(w http.ResponseWriter, r *http.Request) {
+	userIdstr := r.PathValue("userid")
+	userId, err := strconv.ParseInt(userIdstr, 10, 64)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusBadRequest, utils.Response{Message: "Invalid User Id"})
+		return
+	}
+	followers, following, err := f.FollowService.GetFollowFollowingStat(userId)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusInternalServerError, utils.Response{Message: err.Error()})
+		return
+	}
+	var followfollowingstat models.FollowFollowingStat
+	followfollowingstat.NumberOfFollowers = followers
+	followfollowingstat.NumberOfFollowing = following
+
+	utils.RespondJSON(w, http.StatusOK, followfollowingstat)
 }

--- a/backend/internal/api/handlers/follow_handler.go
+++ b/backend/internal/api/handlers/follow_handler.go
@@ -179,3 +179,18 @@ func (f *FollowHandler) GetFollowers(w http.ResponseWriter, r *http.Request) {
 	}
 	utils.RespondJSON(w, http.StatusOK, followers)
 }
+
+func (f *FollowHandler) GetFollowees(w http.ResponseWriter, r *http.Request) {
+	userIdstr := r.PathValue("userid")
+	userId, err := strconv.ParseInt(userIdstr, 10, 64)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusBadRequest, utils.Response{Message: "Invalid User Id"})
+		return
+	}
+	followers, err := f.FollowService.GetFolloweesList(userId)
+	if err != nil {
+		utils.RespondJSON(w, http.StatusInternalServerError, utils.Response{Message: err.Error()})
+		return
+	}
+	utils.RespondJSON(w, http.StatusOK, followers)
+}

--- a/backend/internal/api/handlers/follow_request_handler.go
+++ b/backend/internal/api/handlers/follow_request_handler.go
@@ -101,7 +101,7 @@ func (fr *FollowRequestHandler) FollowRequestRespond(w http.ResponseWriter, r *h
 			followeeName, _, err := fr.FollowRequestService.RetrieveUserName(followeeID)
 			if err == nil {
 				// Store notification in database
-				err =fr.FollowRequestService.AddtoNotification(followerID, followeeName+" rejected your follow request")
+				err = fr.FollowRequestService.AddtoNotification(followerID, followeeName+" rejected your follow request")
 				if err != nil {
 					status = http.StatusInternalServerError
 					serverResponse.Message = "Failed to add notification"
@@ -158,7 +158,7 @@ func (fr *FollowRequestHandler) FollowRequestRespond(w http.ResponseWriter, r *h
 	if fr.Notifier != nil && followerID != 0 {
 		followeeName, _, err := fr.FollowRequestService.RetrieveUserName(followeeID)
 		if err == nil {
-			
+
 			// Store notification in database
 			err = fr.FollowRequestService.AddtoNotification(followerID, followeeName+" accepted your follow request")
 			if err != nil {
@@ -183,5 +183,219 @@ func (fr *FollowRequestHandler) FollowRequestRespond(w http.ResponseWriter, r *h
 	}
 
 	serverResponse.Message = "Successfully accepted follow request"
+	utils.RespondJSON(w, status, serverResponse)
+}
+
+func (fr *FollowRequestHandler) CancelFollowRequestRespond(w http.ResponseWriter, r *http.Request) {
+	var serverResponse utils.Response
+	status := http.StatusOK
+
+	// Get current user id from session (to verify they can respond to this request)
+	_, ok := r.Context().Value(utils.User_id).(int64)
+	if !ok {
+		serverResponse.Message = "User not found in context"
+		utils.RespondJSON(w, http.StatusUnauthorized, serverResponse)
+		return
+	}
+
+	// Parse request ID from URL path
+	requestIDStr := r.PathValue("requestId")
+	requestID, err := strconv.ParseInt(requestIDStr, 10, 64)
+	if err != nil {
+		serverResponse.Message = "Invalid request ID"
+		utils.RespondJSON(w, http.StatusBadRequest, serverResponse)
+		return
+	}
+
+	// Parse request body
+	var requestStatus models.FollowRequestResponseStatus
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		serverResponse.Message = "Failed to read request body"
+		utils.RespondJSON(w, http.StatusBadRequest, serverResponse)
+		return
+	}
+
+	if err = json.Unmarshal(body, &requestStatus); err != nil {
+		serverResponse.Message = "Invalid JSON format"
+		utils.RespondJSON(w, http.StatusBadRequest, serverResponse)
+		return
+	}
+
+	// Validate status value
+	if requestStatus.Status != "accepted" && requestStatus.Status != "rejected" {
+		serverResponse.Message = "Invalid status. Must be 'accepted' or 'rejected'"
+		utils.RespondJSON(w, http.StatusBadRequest, serverResponse)
+		return
+	}
+
+	// Handle rejection
+	if requestStatus.Status == "rejected" {
+		// Get follow request info before rejecting (only if notifications are enabled)
+		var followerID, followeeID int64
+		if fr.Notifier != nil {
+			followerID, followeeID, err = fr.FollowRequestService.GetRequestInfo(requestID)
+			if err != nil {
+				status = http.StatusNotFound
+				serverResponse.Message = "Follow request not found"
+				utils.RespondJSON(w, status, serverResponse)
+				return
+			}
+		}
+
+		err = fr.FollowRequestService.RejectedFollowConnection(requestID)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+				serverResponse.Message = "Follow request not found"
+			} else {
+				status = http.StatusInternalServerError
+				serverResponse.Message = "Failed to reject follow request"
+			}
+			utils.RespondJSON(w, status, serverResponse)
+			return
+		}
+
+		// Send notification to the requester about rejection
+		if fr.Notifier != nil && followerID != 0 {
+			followeeName, _, err := fr.FollowRequestService.RetrieveUserName(followeeID)
+			if err == nil {
+				// Store notification in database
+				err = fr.FollowRequestService.AddtoNotification(followerID, followeeName+" rejected your follow request")
+				if err != nil {
+					status = http.StatusInternalServerError
+					serverResponse.Message = "Failed to add notification"
+					utils.RespondJSON(w, status, serverResponse)
+					return
+				}
+
+				// Send real-time notification if user is online
+				if fr.Notifier.IsOnline(followerID) {
+					fr.Notifier.SendNotification(followerID, map[string]interface{}{
+						"type":      "notification",
+						"subtype":   "follow_request_rejected",
+						"user_id":   followeeID,
+						"user_name": followeeName,
+						"message":   followeeName + " rejected your follow request",
+						"timestamp": time.Now().Unix(),
+					})
+				}
+			}
+		}
+
+		serverResponse.Message = "Successfully rejected follow request"
+		utils.RespondJSON(w, status, serverResponse)
+		return
+	}
+
+	// Handle acceptance
+	// Get follow request info before accepting (only if notifications are enabled)
+	var followerID, followeeID int64
+	if fr.Notifier != nil {
+		followerID, followeeID, err = fr.FollowRequestService.GetRequestInfo(requestID)
+		if err != nil {
+			status = http.StatusNotFound
+			serverResponse.Message = "Follow request not found"
+			utils.RespondJSON(w, status, serverResponse)
+			return
+		}
+	}
+
+	err = fr.FollowRequestService.AcceptedFollowConnection(requestID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			status = http.StatusNotFound
+			serverResponse.Message = "Follow request not found"
+		} else {
+			status = http.StatusInternalServerError
+			serverResponse.Message = "Failed to accept follow request"
+		}
+		utils.RespondJSON(w, status, serverResponse)
+		return
+	}
+
+	// Send notification to the requester about acceptance
+	if fr.Notifier != nil && followerID != 0 {
+		followeeName, _, err := fr.FollowRequestService.RetrieveUserName(followeeID)
+		if err == nil {
+
+			// Store notification in database
+			err = fr.FollowRequestService.AddtoNotification(followerID, followeeName+" accepted your follow request")
+			if err != nil {
+				status = http.StatusInternalServerError
+				serverResponse.Message = "Failed to add notification"
+				utils.RespondJSON(w, status, serverResponse)
+				return
+			}
+
+			// Send real-time notification if user is online
+			if fr.Notifier.IsOnline(followerID) {
+				fr.Notifier.SendNotification(followerID, map[string]interface{}{
+					"type":      "notification",
+					"subtype":   "follow_request_accepted",
+					"user_id":   followeeID,
+					"user_name": followeeName,
+					"message":   followeeName + " accepted your follow request",
+					"timestamp": time.Now().Unix(),
+				})
+			}
+		}
+	}
+
+	serverResponse.Message = "Successfully accepted follow request"
+	utils.RespondJSON(w, status, serverResponse)
+}
+
+func (fr *FollowRequestHandler) CancelFollowRequest(w http.ResponseWriter, r *http.Request) {
+	var serverResponse utils.Response
+	status := http.StatusOK
+
+	// Get current user id from session (to verify they can cancel this request)
+	userID, ok := r.Context().Value(utils.User_id).(int64)
+	if !ok {
+		serverResponse.Message = "User not found in context"
+		utils.RespondJSON(w, http.StatusUnauthorized, serverResponse)
+		return
+	}
+
+	// Parse request ID from URL path
+	requestIDStr := r.PathValue("requestId")
+	requestID, err := strconv.ParseInt(requestIDStr, 10, 64)
+	if err != nil {
+		serverResponse.Message = "Invalid request ID"
+		utils.RespondJSON(w, http.StatusBadRequest, serverResponse)
+		return
+	}
+
+	followerID, _, err := fr.FollowRequestService.GetRequestInfo(requestID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			status = http.StatusNotFound
+			serverResponse.Message = "Follow request not found"
+		} else {
+			status = http.StatusInternalServerError
+			serverResponse.Message = "Failed to retrieve follow request info"
+		}
+		utils.RespondJSON(w, status, serverResponse)
+		return
+	}
+
+	// Check if the current user is the one who made the follow request
+	if followerID != userID {
+		serverResponse.Message = "You can only cancel your own follow requests"
+		utils.RespondJSON(w, http.StatusForbidden, serverResponse)
+		return
+	}
+
+	// Cancel the follow request
+	err = fr.FollowRequestService.CancelFollowRequest(requestID)
+	if err != nil {
+		status = http.StatusInternalServerError
+		serverResponse.Message = "Failed to cancel follow request"
+		utils.RespondJSON(w, status, serverResponse)
+		return
+	}
+
+	serverResponse.Message = "Successfully cancelled follow request"
 	utils.RespondJSON(w, status, serverResponse)
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -75,6 +75,7 @@ func NewRouter(db *sql.DB) http.Handler {
 
 	mux.Handle("POST /follow", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.Follow)))
 	mux.Handle("DELETE /unfollow", middleware.AuthMiddleware(db)(http.HandlerFunc(unfollowHandler.Unfollow)))
+	mux.Handle("GET /users/{userid}/followfollowingstats", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.FollowStats)))
 	mux.Handle("POST /follow-request/{requestId}/request", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.FollowRequestRespond)))
 	mux.Handle("DELETE /follow-request/{requestId}/cancel", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.CancelFollowRequest)))
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -77,6 +77,7 @@ func NewRouter(db *sql.DB) http.Handler {
 	mux.Handle("DELETE /unfollow", middleware.AuthMiddleware(db)(http.HandlerFunc(unfollowHandler.Unfollow)))
 	mux.Handle("GET /users/{userid}/followfollowingstats", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.FollowStats)))
 	mux.Handle("GET /users/{userid}/followers", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.GetFollowers)))
+	mux.Handle("GET /users/{userid}/followees", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.GetFollowees)))
 	mux.Handle("POST /follow-request/{requestId}/request", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.FollowRequestRespond)))
 	mux.Handle("DELETE /follow-request/{requestId}/cancel", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.CancelFollowRequest)))
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -76,6 +76,7 @@ func NewRouter(db *sql.DB) http.Handler {
 	mux.Handle("POST /follow", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.Follow)))
 	mux.Handle("DELETE /unfollow", middleware.AuthMiddleware(db)(http.HandlerFunc(unfollowHandler.Unfollow)))
 	mux.Handle("GET /users/{userid}/followfollowingstats", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.FollowStats)))
+	mux.Handle("GET /users/{userid}/followers", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.GetFollowers)))
 	mux.Handle("POST /follow-request/{requestId}/request", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.FollowRequestRespond)))
 	mux.Handle("DELETE /follow-request/{requestId}/cancel", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.CancelFollowRequest)))
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -76,6 +76,7 @@ func NewRouter(db *sql.DB) http.Handler {
 	mux.Handle("POST /follow", middleware.AuthMiddleware(db)(http.HandlerFunc(followHandler.Follow)))
 	mux.Handle("DELETE /unfollow", middleware.AuthMiddleware(db)(http.HandlerFunc(unfollowHandler.Unfollow)))
 	mux.Handle("POST /follow-request/{requestId}/request", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.FollowRequestRespond)))
+	mux.Handle("DELETE /follow-request/{requestId}/cancel", middleware.AuthMiddleware(db)(http.HandlerFunc(followRequestHandler.CancelFollowRequest)))
 
 	mux.Handle("GET /me", middleware.AuthMiddleware(db)(http.HandlerFunc(handlers.NewMeHandler(db))))
 	mux.Handle("GET /avatar", http.HandlerFunc(handlers.GetImage))

--- a/backend/internal/models/follow.go
+++ b/backend/internal/models/follow.go
@@ -3,3 +3,8 @@ package models
 type Followee struct {
 	FolloweeId int `json:"followeeid"`
 }
+
+type FollowFollowingStat struct {
+	NumberOfFollowers int `json:"numberoffollowers"`
+	NumberOfFollowing int `json:"numberoffollowing"`
+}

--- a/backend/internal/models/follow.go
+++ b/backend/internal/models/follow.go
@@ -8,3 +8,14 @@ type FollowFollowingStat struct {
 	NumberOfFollowers int `json:"numberoffollowers"`
 	NumberOfFollowing int `json:"numberoffollowing"`
 }
+
+type FollowListUser struct {
+	FirstName  string `json:"firstname"`
+	LastName   string `json:"lastname"`
+	Avatar     string `json:"avatar"`
+	FollowerID int64  `json:"follower_id"`
+}
+
+type FollowListResponse struct {
+	Followers []FollowListUser `json:"user"`
+}

--- a/backend/internal/service/follow_request_service.go
+++ b/backend/internal/service/follow_request_service.go
@@ -29,3 +29,7 @@ func (fr *FollowRequestService) GetRequestInfo(requestID int64) (int64, int64, e
 func (fr *FollowRequestService) AddtoNotification(follower_id int64, message string) error {
 	return fr.FollowRequestStore.AddtoNotification(follower_id, message)
 }
+
+func (fr *FollowRequestService) CancelFollowRequest(followConnectionID int64) error {
+	return fr.FollowRequestStore.FollowRequestCancel(followConnectionID)
+}

--- a/backend/internal/service/follow_service.go
+++ b/backend/internal/service/follow_service.go
@@ -40,3 +40,7 @@ func (Follow *FollowService) GetFollowFollowingStat(userId int64) (int, int, err
 func (Follow *FollowService) GetFollowersList(userid int64) (models.FollowListResponse, error) {
 	return Follow.FollowStore.GetUserFollowers(userid)
 }
+
+func (Follow *FollowService) GetFolloweesList(userid int64) (models.FollowListResponse, error) {
+	return Follow.FollowStore.GetUserFollowees(userid)
+}

--- a/backend/internal/service/follow_service.go
+++ b/backend/internal/service/follow_service.go
@@ -31,3 +31,7 @@ func (Follow *FollowService) GetUserInfo(userID int64) (string, string, error) {
 func (Follow *FollowService) AddtoNotification(follower_id int64, message string) error {
 	return Follow.FollowStore.AddtoNotification(follower_id, message)
 }
+
+func (Follow *FollowService) GetFollowFollowingStat(userId int64) (int, int, error) {
+	return Follow.FollowStore.CountFollowFollowers(userId)
+}

--- a/backend/internal/service/follow_service.go
+++ b/backend/internal/service/follow_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/tajjjjr/social-network/backend/internal/models"
 	"github.com/tajjjjr/social-network/backend/internal/store"
 )
 
@@ -34,4 +35,8 @@ func (Follow *FollowService) AddtoNotification(follower_id int64, message string
 
 func (Follow *FollowService) GetFollowFollowingStat(userId int64) (int, int, error) {
 	return Follow.FollowStore.CountFollowFollowers(userId)
+}
+
+func (Follow *FollowService) GetFollowersList(userid int64) (models.FollowListResponse, error) {
+	return Follow.FollowStore.GetUserFollowers(userid)
 }

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -43,6 +43,7 @@ type UnfollowServiceInterface interface {
 type FollowRequestServiceInterface interface {
 	AcceptedFollowConnection(followConnectionID int64) error
 	RejectedFollowConnection(followConnectionID int64) error
+	CancelFollowRequest(followConnectionID int64) error
 	RetrieveUserName(userID int64) (string, string, error)
 	GetRequestInfo(requestID int64) (int64, int64, error)
 	AddtoNotification(follower_id int64, message string) error

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -33,6 +33,7 @@ type FollowServiceInterface interface {
 	CreateFollowForPrivateAccount(followrid, followeeid int64) (int64, error)
 	GetUserInfo(userID int64) (string, string, error)
 	AddtoNotification(follower_id int64, message string) error
+	GetFollowFollowingStat(userId int64) (int, int, error)
 }
 
 type UnfollowServiceInterface interface {

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -35,6 +35,7 @@ type FollowServiceInterface interface {
 	AddtoNotification(follower_id int64, message string) error
 	GetFollowFollowingStat(userId int64) (int, int, error)
 	GetFollowersList(userid int64) (models.FollowListResponse, error)
+	GetFolloweesList(userid int64) (models.FollowListResponse, error)
 }
 
 type UnfollowServiceInterface interface {

--- a/backend/internal/service/interfaces.go
+++ b/backend/internal/service/interfaces.go
@@ -34,6 +34,7 @@ type FollowServiceInterface interface {
 	GetUserInfo(userID int64) (string, string, error)
 	AddtoNotification(follower_id int64, message string) error
 	GetFollowFollowingStat(userId int64) (int, int, error)
+	GetFollowersList(userid int64) (models.FollowListResponse, error)
 }
 
 type UnfollowServiceInterface interface {

--- a/backend/internal/store/follow_request_store.go
+++ b/backend/internal/store/follow_request_store.go
@@ -93,3 +93,8 @@ func (followstore *FollowRequestStore) AddtoNotification(follower_id int64, mess
 		follower_id, notificationType, message)
 	return err
 }
+
+func (fr *FollowRequestStore) FollowRequestCancel(requestID int64) error {
+	_, err := fr.DB.Exec("DELETE FROM Followers WHERE id = ? AND status = 'pending'", requestID)
+	return err
+}

--- a/backend/internal/store/follow_store.go
+++ b/backend/internal/store/follow_store.go
@@ -139,3 +139,44 @@ func (followstore *FollowStore) GetUserFollowers(userid int64) (models.FollowLis
 
 	return followersList, nil
 }
+
+
+func (followstore *FollowStore) GetUserFollowees(userid int64) (models.FollowListResponse, error) {
+	var followersList models.FollowListResponse
+	rows, err := followstore.DB.Query(`
+		SELECT u.id, u.first_name, u.last_name, u.avatar 
+		FROM Users u 
+		INNER JOIN Followers f ON u.id = f.followee_id 
+		WHERE f.follower_id = ? AND f.status = 'accepted'`, userid)
+	if err != nil {
+		return followersList, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var follower models.FollowListUser
+		var firstName, lastName, avatar sql.NullString
+		err := rows.Scan(&follower.FollowerID, &firstName, &lastName, &avatar)
+		if err != nil {
+			return followersList, err
+		}
+
+		if firstName.Valid {
+			follower.FirstName = firstName.String
+		}
+		if lastName.Valid {
+			follower.LastName = lastName.String
+		}
+		if avatar.Valid {
+			follower.Avatar = avatar.String
+		}
+
+		followersList.Followers = append(followersList.Followers, follower)
+	}
+
+	if err = rows.Err(); err != nil {
+		return followersList, err
+	}
+
+	return followersList, nil
+}

--- a/backend/internal/store/follow_store.go
+++ b/backend/internal/store/follow_store.go
@@ -83,3 +83,17 @@ func (followstore *FollowStore) AddtoNotification(follower_id int64, message str
 		follower_id, notificationType, message)
 	return err
 }
+
+func (followStore *FollowStore) CountFollowFollowers(userid int64) (int, int, error) {
+	followers := 0
+	following := 0
+	err := followStore.DB.QueryRow("SELECT COUNT(*) FROM Followers WHERE follower_id = ? AND status = 'accepted'", userid).Scan(&followers)
+	if err != nil {
+		return 0, 0, err
+	}
+	err = followStore.DB.QueryRow("SELECT COUNT(*) FROM Followers WHERE followee_id = ? AND status = 'accepted'", userid).Scan(&following)
+	if err != nil {
+		return 0, 0, err
+	}
+	return followers, following, nil
+}


### PR DESCRIPTION
Description:

This PR introduces the following updates to the follow system:

    ✅ Added handler to get followers/followings count (stats).

    ✅ Added handler to retrieve a list of followers for a user.

    ✅ Added handler to retrieve a list of followees (users being followed) for a user.

These endpoints are part of enhancing the social functionality, allowing users to view their network stats and connections.

Checklist:
Response structures follow the API standards