### PR TITLE
135 create groups and events database structure

### DIFF
--- a/backend/pkg/db/migrations/sqlite/000023_create_group_post_reactions_table.down.sql
+++ b/backend/pkg/db/migrations/sqlite/000023_create_group_post_reactions_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Group_Post_Reactions;

--- a/backend/pkg/db/migrations/sqlite/000023_create_group_post_reactions_table.up.sql
+++ b/backend/pkg/db/migrations/sqlite/000023_create_group_post_reactions_table.up.sql
@@ -1,0 +1,14 @@
+-- Create Group_Post_Reactions table
+CREATE TABLE IF NOT EXISTS Group_Post_Reactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_post_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    reaction_type TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (group_post_id) REFERENCES Group_Posts(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES Users(id) ON DELETE CASCADE,
+    UNIQUE(group_post_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_post_reactions_group_post_id ON Group_Post_Reactions(group_post_id);
+CREATE INDEX IF NOT EXISTS idx_group_post_reactions_user_id ON Group_Post_Reactions(user_id);

--- a/backend/pkg/db/migrations/sqlite/000024_create_group_comment_reactions_table.down.sql
+++ b/backend/pkg/db/migrations/sqlite/000024_create_group_comment_reactions_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Group_Comment_Reactions;

--- a/backend/pkg/db/migrations/sqlite/000024_create_group_comment_reactions_table.up.sql
+++ b/backend/pkg/db/migrations/sqlite/000024_create_group_comment_reactions_table.up.sql
@@ -1,0 +1,14 @@
+-- Create Group_Comment_Reactions table
+CREATE TABLE IF NOT EXISTS Group_Comment_Reactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    comment_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    reaction_type TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (comment_id) REFERENCES Group_Post_Comments(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES Users(id) ON DELETE CASCADE,
+    UNIQUE(comment_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_comment_reactions_comment_id ON Group_Comment_Reactions(comment_id);
+CREATE INDEX IF NOT EXISTS idx_group_comment_reactions_user_id ON Group_Comment_Reactions(user_id);

--- a/backend/pkg/db/migrations/sqlite/000025_create_group_post_comments_table.down.sql
+++ b/backend/pkg/db/migrations/sqlite/000025_create_group_post_comments_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Group_Post_Comments;

--- a/backend/pkg/db/migrations/sqlite/000025_create_group_post_comments_table.up.sql
+++ b/backend/pkg/db/migrations/sqlite/000025_create_group_post_comments_table.up.sql
@@ -1,0 +1,16 @@
+-- Create Group_Post_Comments table
+CREATE TABLE IF NOT EXISTS Group_Post_Comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_post_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    parent_comment_id INTEGER,
+    content TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (group_post_id) REFERENCES Group_Posts(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES Users(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_comment_id) REFERENCES Group_Post_Comments(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_post_comments_group_post_id ON Group_Post_Comments(group_post_id);
+CREATE INDEX IF NOT EXISTS idx_group_post_comments_user_id ON Group_Post_Comments(user_id);

--- a/backend/pkg/db/migrations/sqlite/000026_create_group_requests_table.down.sql
+++ b/backend/pkg/db/migrations/sqlite/000026_create_group_requests_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS Group_Requests;

--- a/backend/pkg/db/migrations/sqlite/000026_create_group_requests_table.up.sql
+++ b/backend/pkg/db/migrations/sqlite/000026_create_group_requests_table.up.sql
@@ -1,0 +1,13 @@
+-- Create Group_Requests table
+CREATE TABLE IF NOT EXISTS Group_Requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'rejected')),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (group_id) REFERENCES Groups(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES Users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_requests_group_id ON Group_Requests(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_requests_user_id ON Group_Requests(user_id);


### PR DESCRIPTION
**WIP:**
**Title: feat(db): Add migrations for group functionality.**
**Descritpion:**
 >  This PR introduces the necessary database migrations to support the new groups feature. It adds the following tables:

   * group_post_reactions: To store reactions on group posts.
   * group_comment_reactions: To store reactions on group post comments.
   * group_post_comments: To store comments on group posts.
   * group_requests: To manage user requests to join private groups.